### PR TITLE
move edit and reviewer to new class

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -39,28 +39,3 @@ But if you need to retreive result exactly from Server rather than
 cache, you can disable it in GerritClient object::
 
     client = GerritClient("https://xxxx.gerrit.com/", cache=False)
-
-Handling exceptions
--------------------
-
-You can use ``try catch`` to handle exceptions::
-
-    from Gerrit.exception import  GerritError
-    from Gerrit.client import GerritClient
-    from requests.auth import HTTPBasicAuth
-
-    auth = HTTPBasicAuth("xxxxxxxxxxxxxxxx","xxxxxxxxxxxxxxxxxx")
-    client = GerritClient("http://xxxxxxxxx.gerrit.com/", auth=auth)
-
-    try:
-      change = client.change("111111111111111111111") #obviously this is a non-exist change
-      detail = change.detail()
-    except GerritError as e:
-      print(e.status, e.content)
-    else:
-      pass
-    finally:
-      pass
-
-Result
-    ``404 b'Not found: 111111111111111111111\n'``

--- a/pGerrit/change.py
+++ b/pGerrit/change.py
@@ -14,10 +14,13 @@ class GerritChange(GerritClient):
     _endpoint = "/a/changes/{}"
     _args = ["id"]
 
-    def __init__(self, host, gerritID=None, auth=None, verify=True, adapter=None, cache=True, cache_expire=3):
+    def __init__(self, host, gerritID, auth=None, verify=True, adapter=None, cache=True, cache_expire=3):
         """See class docstring."""
         super().__init__(host, auth=auth, verify=verify, adapter=adapter, cache=cache, cache_expire=cache_expire)
         self.id = gerritID
+
+        self.args = [host, gerritID]
+        self.kwargs = {"auth": auth, "verify": verify, "adapter":adapter, "cache":cache, "cache_expire":cache_expire}
 
     @classmethod
     @GerritRest.get()
@@ -61,20 +64,6 @@ class GerritChange(GerritClient):
 
         """
         return urljoin(self.host, urlformat(GerritChange._endpoint, self.id))
-
-    def is_merge(self):
-        """Checks if the change is a merge change.
-
-        Usage::
-
-            is_merge_change = change.is_merge()
-
-        """
-        revision = self.current_revision()
-        if len(revision.commit().parents) == 2:
-            return True
-        else:
-            return False
 
     @GerritRest.get()
     @GerritRest.url_wrapper()
@@ -126,6 +115,24 @@ class GerritChange(GerritClient):
         Usage::
 
             change.set_topic({"topic": "new-topic"})
+
+        """
+        pass
+
+    @GerritRest.delete
+    @GerritRest.url_wrapper("topic")
+    def delete_topic(self, *args, **kwargs):
+        """Performs a PUT request to set the topic of a change.
+
+        **API URL**: `/a/changes/{change_id}/topic <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-topic>`__
+
+        **Input type**: None
+
+        **Return type**: None
+
+        Usage::
+
+            change.delete_topic()
 
         """
         pass
@@ -240,60 +247,6 @@ class GerritChange(GerritClient):
 
     @GerritRest.get()
     @GerritRest.url_wrapper()
-    def edit(self, *args, **kwargs):
-        """Performs a GET request to retrieve information about the change edit.
-
-        **API URL**: `/a/changes/{change_id}/edit <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#edit-endpoints>`__
-
-        **Input type**: None
-
-        **Return type**: `EditInfo <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#edit-info>`__
-
-        Usage::
-
-            change.edit()
-
-        """
-        pass
-
-    @GerritRest.get()
-    @GerritRest.url_wrapper()
-    def reviewers(self, *args, **kwargs):
-        """Performs a GET request to retrieve the list of reviewers for a change.
-
-        **API URL**: `/a/changes/{change_id}/reviewers <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-reviewers>`__
-
-        **Input type**: None
-
-        **Return type**: List[`ReviewerInfo <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#reviewer-info>`__]
-
-        Usage::
-
-            change.reviewers()
-
-        """
-        pass
-
-    @GerritRest.post
-    @GerritRest.url_wrapper("reviewers")
-    def add_reviewer(self, *args, **kwargs):
-        """Performs a POST request to add a reviewer to a change.
-
-        **API URL**: `/a/changes/{change_id}/reviewers <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#add-reviewer>`__
-
-        **Input type**: `ReviewerInput <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#reviewer-input>`__
-
-        **Return type**: `ReviewerResult <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#reviewer-result>`__
-
-        Usage::
-
-            change.add_reviewer({"reviewer": "example@example.com"})
-
-        """
-        pass
-
-    @GerritRest.get()
-    @GerritRest.url_wrapper()
     def hashtags(self, *args, **kwargs):
         """Performs a GET request to retrieve the hashtags associated with a change.
 
@@ -312,7 +265,7 @@ class GerritChange(GerritClient):
 
     @GerritRest.post
     @GerritRest.url_wrapper("hashtags")
-    def set_hashtags(self, *args, **kwargs):
+    def set_hashtags(self, payload=None, *args, **kwargs):
         """Performs a POST request to add or remove hashtags from a change.
 
         **API URL**: `/a/changes/{change_id}/hashtags <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-hashtags>`__
@@ -323,25 +276,7 @@ class GerritChange(GerritClient):
 
         Usage::
 
-            change.set_hashtags(add=["tag1"], remove=["tag2"])
-
-        """
-        pass
-
-    @GerritRest.get()
-    @GerritRest.url_wrapper()
-    def suggest_reviewers(self, *args, **kwargs):
-        """Performs a GET request to retrieve a list of suggested reviewers for a change.
-
-        **API URL**: `/a/changes/{change_id}/suggest_reviewers <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#suggest-reviewers>`__
-
-        **Input type**: `SuggestReviewersOptions <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#suggest-reviewers>`__
-
-        **Return type**: List[`SuggestedReviewerInfo <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#suggested-reviewer-info>`__]
-
-        Usage::
-
-            change.suggest_reviewers(q="john")
+            change.set_hashtags(payload={"add":["tag1"], "remove":["tag2"]})
 
         """
         pass
@@ -364,60 +299,6 @@ class GerritChange(GerritClient):
         """
         pass
 
-    @GerritRest.post
-    @GerritRest.url_wrapper("edit:publish")
-    def edit_publish(self, payload=None, headers=None):
-        """Performs a POST request to publish a change edit.
-
-        **API URL**: `/a/changes/{change_id}/edit:publish <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#publish-edit>`__
-
-        **Input type**: `PublishChangeEditInput <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#publish-change-edit-input>`__ (optional)
-
-        **Return type**: None
-
-        Usage::
-
-            change.edit_publish()
-
-        """
-        pass
-
-    @GerritRest.post
-    @GerritRest.url_wrapper("edit")
-    def edit_restore(self, payload=None, headers=None):
-        """Performs a POST request to restore a change edit.
-
-        **API URL**: `/a/changes/{change_id}/edit <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#post-edit>`__
-
-        **Input type**: `ChangeEditInput <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#change-edit-input>`__
-        
-        **Return type**: None
-
-        Usage::
-
-            change.edit_restore({"restore_path": "foo"})
-
-        """
-        pass
-
-    @GerritRest.delete
-    @GerritRest.url_wrapper("edit")
-    def edit_delete(self, payload=None, headers=None):
-        """Performs a DELETE request to delete a change edit.
-
-        **API URL**: `/a/changes/{change_id}/edit <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-edit>`__
-
-        **Input type**: None
-
-        **Return type**: None
-
-        Usage::
-
-            change.edit_delete()
-
-        """
-        pass
-
     @GerritRest.delete
     @GerritRest.url_wrapper("")
     def delete_change(self, payload=None, headers=None):
@@ -435,6 +316,21 @@ class GerritChange(GerritClient):
 
         """
         pass
+
+    def is_merge(self):
+        """Checks if the change is a merge change.
+
+        Usage::
+
+            is_merge_change = change.is_merge()
+
+        """
+        revision = self.current_revision()
+        if len(revision.commit().parents) == 2:
+            return True
+        else:
+            return False
+
 
     def revision(self, revisionID):
         """Creates a GerritChangeRevision object for a specific revision of the change.
@@ -457,6 +353,234 @@ class GerritChange(GerritClient):
 
         """
         return GerritChangeRevision(self.host, self.id, "current", auth=self.session.auth, verify=self.verify, adapter=self.adapter, cache=self.cache, cache_expire=self.cache_expire)
+
+    @property
+    def edit(self):
+        """Provides an instance of GerritChangeEditQueryDescriptor for the given Gerrit client configuration.
+
+        :return: An instance of GerritChangeEditQueryDescriptor.
+        :rtype: pGerrit.queryDescriptor.GerritChangeEditQueryDescriptor
+
+        Usage::
+
+            change = GerritChange(...)
+            edit_info = change.edit.info()
+            edited_content = change.edit("COMMIT_MSG").edit_retrieve()
+
+        """
+        from pGerrit.queryDescriptor import GerritChangeEditQueryDescriptor
+        return GerritChangeEditQueryDescriptor(self)
+
+    @property
+    def reviewer(self):
+        """Provides an instance of GerritChangeReviewerQueryDescriptor for the given Gerrit client configuration.
+
+        :return: An instance of GerritChangeReviewerQueryDescriptor.
+        :rtype: pGerrit.queryDescriptor.GerritChangeReviewerQueryDescriptor
+
+        Usage::
+
+            change = GerritChange(...)
+            reviewers = change.reviewer.query()
+            suggested_reviewers = change.reviewer.suggest_reviewers(q="john")
+            result = change.reviewer.add_reviewer({"reviewer": "example@example.com"})
+
+        """
+        from pGerrit.queryDescriptor import GerritChangeReviewerQueryDescriptor
+        return GerritChangeReviewerQueryDescriptor(self)
+
+class GerritChangeEdit(GerritChange):
+    """Class maps /a/changes/{change_id}/edit endpoint of Gerrit REST API
+
+    :return: An instance of GerritChangeEdit.
+    :rtype: pGerrit.change.GerritChangeEdit
+
+    You won't need to instantiate this Class directly.
+    Use ``pGerrit.change.GerritChange.revision``
+    """
+    _endpoint = "/a/changes/{}/edit/{}"
+    _args = ["id", "fileID"]
+
+    def __init__(self, host, gerritID, fileID, auth=None, verify=True, adapter=None, cache=True, cache_expire=3):
+        """See class docstring."""
+        super().__init__(host, gerritID, auth=auth, verify=verify, adapter=adapter, cache=cache, cache_expire=cache_expire)
+        self.fileID = fileID
+
+    @classmethod
+    @GerritRest.get()
+    def info(self, *args, **kwargs):
+        """Performs a GET request to retrieve information about the change edit.
+
+        **API URL**: `/a/changes/{change_id}/edit <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#edit-endpoints>`__
+
+        **Input type**: None
+
+        **Return type**: `EditInfo <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#edit-info>`__
+
+        Usage::
+
+            edit.info()
+
+        """
+        return urljoin(self.host, urlformat(GerritChangeEdit._endpoint, self.id, ""))
+
+    @classmethod
+    @GerritRest.post
+    @GerritRest.url_wrapper("edit:publish")
+    def edit_publish(self, payload=None, headers=None):
+        """Performs a POST request to publish a change edit.
+
+        **API URL**: `/a/changes/{change_id}/edit/edit:publish <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#publish-edit>`__
+
+        **Input type**: `PublishChangeEditInput <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#publish-change-edit-input>`__ (optional)
+
+        **Return type**: None
+
+        Usage::
+
+            edit.edit_publish()
+
+        """
+        pass
+
+    @classmethod
+    @GerritRest.post
+    @GerritRest.url_wrapper("edit")
+    def edit_restore(self, payload=None, headers=None):
+        """Performs a POST request to restore a change edit.
+
+        **API URL**: `/a/changes/{change_id}/edit <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#post-edit>`__
+
+        **Input type**: `ChangeEditInput <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#change-edit-input>`__
+        
+        **Return type**: None
+
+        Usage::
+
+            edit.edit_restore({"restore_path": "foo"})
+
+        """
+        pass
+
+    @classmethod
+    @GerritRest.delete
+    @GerritRest.url_wrapper("edit")
+    def edit_delete(self, headers=None):
+        """Performs a DELETE request to delete a change edit.
+
+        **API URL**: `/a/changes/{change_id}/edit <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#delete-edit>`__
+
+        **Input type**: None
+
+        **Return type**: None
+
+        Usage::
+
+            edit.edit_delete()
+
+        """
+        pass
+
+    @GerritRest.put
+    @GerritRest.url_wrapper()
+    def edit_file(self, payload, headers=None):
+        """Performs a PUT request to edit a specific file in a change revision.
+
+        **API URL**: `/a/changes/{change_id}/edit/{file_id} <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#edit-file>`__
+
+        **Input type**: str
+
+        **Return type**: None
+
+        Usage::
+
+            edit_file.edit(payload='new_file_content')
+
+        """
+        pass
+
+    @GerritRest.get()
+    @GerritRest.url_wrapper()
+    def edit_retrieve(self, headers=None):
+        """Performs a GET request to retrieve the content of a specific file in a change revision after editing.
+
+        **API URL**: `/a/changes/{change_id}/edit/{file_id} <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-edit>`__
+
+        **Input type**: None
+
+        **Return type**: str
+
+        Usage::
+
+            edited_content = edit_file.edit_retrieve()
+
+        """
+        pass
+
+class GerritChangeReviewer(GerritChange):
+    """Class maps /a/changes/{change_id}/reviewers/{account_id} endpoint of Gerrit REST API
+
+    :return: An instance of GerritChangeReviewer.
+    :rtype: pGerrit.change.GerritChangeReviewer
+
+    You won't need to instantiate this Class directly.
+    Use ``pGerrit.change.GerritChange.reviewer``
+    """
+    _endpoint = "/a/changes/{}/reviewers/{}"
+    _args = ["id", "account_id"]
+
+    def __init__(self, host, account_id, auth=None, verify=True, adapter=None, cache=True, cache_expire=3):
+        """See class docstring."""
+        super().__init__(host, gerritID, auth=auth, verify=verify, adapter=adapter, cache=cache, cache_expire=cache_expire)
+        self.account_id = account_id
+
+    @classmethod
+    @GerritRest.get()
+    def query(self, *args, **kwargs):
+        """Performs a GET request to retrieve information about the change edit.
+
+        **API URL**: `/a/changes/{change_id}/reviewers/ <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-reviewers>`__
+
+        **Input type**: None
+        """
+        return urljoin(self.host, urlformat(GerritChangeReviewer._endpoint, self.id, ""))
+
+    @classmethod
+    @GerritRest.get()
+    def suggest_reviewers(self, *args, **kwargs):
+        """Performs a GET request to retrieve a list of suggested reviewers for a change.
+
+        **API URL**: `/a/changes/{change_id}/suggest_reviewers <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#suggest-reviewers>`__
+
+        **Input type**: `SuggestReviewersOptions <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#suggest-reviewers>`__
+
+        **Return type**: List[`SuggestedReviewerInfo <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#suggested-reviewer-info>`__]
+
+        Usage::
+
+            reviewer.suggest_reviewers(q="john")
+
+        """
+        return urljoin(self.host, urlformat("/a/changes/{}/suggest_reviewers", self.id, "suggest_reviewers"))
+
+    @classmethod
+    @GerritRest.post
+    def add_reviewer(self, payload=None, *args, **kwargs):
+        """Performs a POST request to add a reviewer to a change.
+
+        **API URL**: `/a/changes/{change_id}/reviewers <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#add-reviewer>`__
+
+        **Input type**: `ReviewerInput <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#reviewer-input>`__
+
+        **Return type**: `ReviewerResult <https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#reviewer-result>`__
+
+        Usage::
+
+            reviewer.add_reviewer({"reviewer": "example@example.com"})
+
+        """
+        return urljoin(self.host, urlformat(self._endpoint, self.id, ""))
+
 
 class GerritChangeRevision(GerritChange):
     """Class maps /a/changes/{change_id}/revisions/{revision_id} endpoint of Gerrit REST API
@@ -706,7 +830,7 @@ class GerritChangeRevision(GerritChange):
         """
         return GerritChangeRevisionFile(self.host, self.id, self.revisionID, fileID, auth=self.session.auth, verify=self.verify, adapter=self.adapter, cache=self.cache, cache_expire=self.cache_expire)
 
-    def reviwer(self, accountID):
+    def reviewer(self, accountID):
         """Get the GerritChangeRevisionReviewer instance for a specific reviewer of the change revision.
 
         :arg str accountID: The ID of the reviewer.
@@ -892,40 +1016,3 @@ class GerritChangeRevisionFile(GerritChangeRevision):
         project = self.info().project
         commit = commit or self.commit().commit
         return urljoin(self.host, "a/plugins", "gitiles", project, "+log", commit, self.fileID)
-
-    @GerritRest.put
-    def edit(self, payload, headers=None):
-        """Edit a specific file in a change revision.
-
-        :param payload: The file content to be updated.
-        :type payload: str
-        :param headers: (optional) Additional headers to send with the request.
-        :type headers: dict
-
-        :return: The URL for the edited file.
-        :rtype: str
-
-        Usage::
-
-            edit_url = revision_file.edit(payload='new_file_content')
-
-        """
-        return urljoin(self.host, "/a/changes/", self.id, "/edit/", urlformat("{}", self.fileID))
-
-    @GerritRest.get()
-    def edit_retrieve(self, headers=None):
-        """Retrieve the content of a specific file in a change revision after editing.
-
-        :param headers: (optional) Additional headers to send with the request.
-        :type headers: dict
-
-        :return: The content of the specified file in the change revision after editing.
-        :rtype: str
-
-        Usage::
-
-            edited_content = revision_file.edit_retrieve()
-
-        """
-        return urljoin(self.host, "/a/changes/", self.id, "/edit/", urlformat("{}", self.fileID))
-

--- a/pGerrit/exception.py
+++ b/pGerrit/exception.py
@@ -1,4 +1,0 @@
-class GerritError(Exception):
-    def __init__(self, status, content):
-        self.status = status
-        self.content = content

--- a/pGerrit/queryDescriptor.py
+++ b/pGerrit/queryDescriptor.py
@@ -1,6 +1,6 @@
 # This file is to implement query classmethod from GerritClient withous passing host arguement
 # In oder to make IDE autocomple work , we need to return exact type from __call__ method
-from pGerrit.change import GerritChange
+from pGerrit.change import GerritChange, GerritChangeEdit, GerritChangeReviewer
 from pGerrit.Access import GerritAccess
 
 class QueryDescriptor(object):
@@ -26,6 +26,49 @@ class GerritChangeQueryDescriptor(QueryDescriptor):
         :rtype: pGerrit.change.GerritChange
         '''
         return GerritChange(*self.factory_obj.args, *args,  **self.factory_obj.kwargs, **kwargs)
+
+class GerritChangeEditQueryDescriptor(QueryDescriptor):
+    def __init__(self, factory_obj):
+        super().__init__(factory_obj)
+
+    def info(self, *args, **kwargs):
+        return GerritChangeEdit.info.__func__(self.factory_obj, *args, **kwargs)
+
+    def edit_publish(self, payload=None, headers=None):
+        return GerritChangeEdit.edit_publish.__func__(self.factory_obj, payload=payload, headers=headers)
+
+    def edit_restore(self, payload=None, headers=None):
+        return GerritChangeEdit.edit_restore.__func__(self.factory_obj, payload=payload, headers=headers)
+
+    def edit_delete(self, headers=None):
+        return GerritChangeEdit.edit_delete.__func__(self.factory_obj, headers=headers)
+
+    def __call__(self, *args, **kwargs):
+        '''
+        :return: An instance of GerritChangeEdit.
+        :rtype: pGerrit.change.GerritChangeEdit
+        '''
+        return GerritChangeEdit(*self.factory_obj.args, *args, **self.factory_obj.kwargs, **kwargs)
+
+class GerritChangeReviewerQueryDescriptor(QueryDescriptor):
+    def __init__(self, factory_obj):
+        super().__init__(factory_obj)
+
+    def query(self, *args, **kwargs):
+        return GerritChangeReviewer.query.__func__(self.factory_obj, *args, **kwargs)
+
+    def suggest_reviewers(self, *args, **kwargs):
+        return GerritChangeReviewer.suggest_reviewers.__func__(self.factory_obj, *args, **kwargs)
+
+    def add_reviewer(self, *args, **kwargs):
+        return GerritChangeReviewer.add_reviewer.__func__(self.factory_obj, *args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        '''
+        :return: An instance of GerritChangeReviewer.
+        :rtype: pGerrit.change.GerritChangeReviewer
+        '''
+        return GerritChangeReviewer(*self.factory_obj.args, *args, **self.factory_obj.kwargs, **kwargs)
 
 class GerritAccessQueryDescriptor(QueryDescriptor):
     def __init__(self, factory_obj):

--- a/pGerrit/restAPIwrapper.py
+++ b/pGerrit/restAPIwrapper.py
@@ -2,7 +2,6 @@ from functools import wraps
 import requests
 from types import SimpleNamespace
 from pGerrit.utils import urljoin, urlformat
-from pGerrit.exception import GerritError
 import json
 from typing import Callable
 
@@ -20,11 +19,12 @@ class GerritRest(object):
                 url = url if self.session.auth else url.replace("/a/", "/")
                 res = self.session.get(url, headers=headers, verify=self.kwargs["verify"], params=kwargs)
                 res._content = res._content.replace(b")]}'\n", b"")
-                if res.status_code != 200:
-                    raise GerritError(res.status_code, res.content)
+                res.raise_for_status()
 
                 if raw:
                     return res
+                elif res.content == b'':
+                    return res.content
                 else:
                     return res.json(object_hook=lambda d: SimpleNamespace(**d))
             return decorator_get
@@ -36,6 +36,7 @@ class GerritRest(object):
             url = func(self, payload, headers=headers, *args, **kwargs)
             url = url if self.session.auth else url.replace("/a/", "/")
             res = self.session.put(url, payload, headers=headers, verify=self.kwargs["verify"], params=kwargs)
+            res.raise_for_status()
             # res._content = res._content.replace(b")]}'\n", b"")
             # des.resultType
             return res
@@ -47,6 +48,7 @@ class GerritRest(object):
             url = func(self, payload, headers=headers, *args, **kwargs)
             url = url if self.session.auth else url.replace("/a/", "/")
             res = self.session.post(url, json.dumps(payload), headers=headers, verify=self.kwargs["verify"], params=kwargs)
+            res.raise_for_status()         
             # res._content = res._content.replace(b")]}'\n", b"")
             # des.resultType
             return res
@@ -58,6 +60,7 @@ class GerritRest(object):
             url = func(self, headers=headers, *args, **kwargs)
             url = url if self.session.auth else url.replace("/a/", "/")
             res = self.session.delete(url, headers=headers, verify=self.kwargs["verify"], params=kwargs)
+            res.raise_for_status()
             # res._content = res._content.replace(b")]}'\n", b"")
             # des.resultType
             return res
@@ -67,7 +70,7 @@ class GerritRest(object):
         def wrapper(func):
             @wraps(func)
             def decorator_url(self, *args, **kwargs):
-                from pGerrit.change import GerritChange, GerritChangeRevision, GerritChangeRevisionFile
+                from pGerrit.change import GerritChange, GerritChangeRevision, GerritChangeRevisionFile, GerritChangeEdit, GerritChangeReviewer
                 name = end if end != None else func.__name__
                 # find the class defined the method
                 cls_d = eval(func.__qualname__.split(".")[-2])


### PR DESCRIPTION
edit and reviewer are standalone endpoint
We obey the design rule of "one endpoint one clss"

1. move functions to new class
2. write test cases a tiny fix
1. use a response.raise_for_status() rather then own exceptions